### PR TITLE
Added NAMESPACE param to get secret call in save_certs.sh

### DIFF
--- a/save_certs.sh
+++ b/save_certs.sh
@@ -25,9 +25,9 @@ CERT=$(cat $CERT_LOCATION/$DOMAIN/fullchain.pem | base64 --wrap=0)
 KEY=$(cat $CERT_LOCATION/$DOMAIN/privkey.pem | base64 --wrap=0)
 DHPARAM=$(openssl dhparam 2048 | base64 --wrap=0)
 
-kubectl get secrets $SECRET_NAME && ACTION=replace || ACTION=create;
-
 NAMESPACE=${NAMESPACE:-default}
+
+kubectl get secrets --namespace $NAMESPACE $SECRET_NAME && ACTION=replace || ACTION=create;
 
 cat << EOF | kubectl $ACTION -f -
 {


### PR DESCRIPTION
The `NAMESPACE` env variable wasn't used in the call to `kubectl get secret` in `save_certs.sh`. This commit fixes that.
