### PR TITLE
Update the version of kubectl to 1.3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN ./letsencrypt-auto; exit 0
 RUN echo "OK" > /letsencrypt/challenges/.well-known/acme-challenge/health
 
 # Install kubectl
-RUN wget https://storage.googleapis.com/kubernetes-release/release/v1.2.2/bin/linux/amd64/kubectl
+RUN wget https://storage.googleapis.com/kubernetes-release/release/v1.3.6/bin/linux/amd64/kubectl
 RUN chmod +x kubectl
 RUN mv kubectl /usr/local/bin/
 


### PR DESCRIPTION
 To accommodate the change of saving secrets.
The thing is I was having trouble saving my certificate with 1.2.2 kubectl. So I need to update it. I don't know if others (or yourself) having the same issue. If no, just ignore it.

btw, great work! helped me a lot!

Regards,
Ken
