### PR TITLE
Adding admin key resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,13 @@ kubectl exec -it <pod> -- bash -c 'EMAIL=fred@fred.com DOMAINS=example.com foo.e
  - DOMAINS - a space separated list of domains to obtain a certificate for.
  - LETSENCRYPT_ENDPOINT
    - If set, will be used to populate the /etc/letsencrypt/cli.ini file with
-     the given server value. For testing use
+     the given server value. For testing use.
      https://acme-staging.api.letsencrypt.org/directory
  - DEPLOYMENTS - a space separated list of deployments whose pods should be
-   refreshed after a certificate save
- - SECRET_NAME - the name to save the secrets under
- - NAMESPACE - the namespace under which the secrets should be available
+   refreshed after a certificate save.
+ - SECRET_NAME - the name to save the secrets under.
+ - NAMESPACE - the namespace under which the secrets should be available.
+ - KUBECTL_ACCESS_SECURED - the flag to use or not the below variables. (e.g. value: "true" or "false")
+ - CA_CERT_PATH , ADMIN_KEY_PATH , ADMIN_CERT_PATH - the absolutes path to files that are used by kubectl.
  - CRON_FREQUENCY - the 5-part frequency of the cron job. Default is a random
    time in the range `0-59 0-23 1-27 * *`

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ kubectl exec -it <pod> -- bash -c 'EMAIL=fred@fred.com DOMAINS=example.com foo.e
  - SECRET_NAME - the name to save the secrets under.
  - NAMESPACE - the namespace under which the secrets should be available.
  - KUBECTL_ACCESS_SECURED - the flag to use or not the below variables. (e.g. value: "true" or "false")
- - CA_CERT_PATH , ADMIN_KEY_PATH , ADMIN_CERT_PATH - the absolutes path to files that are used by kubectl.
+ - CA_CERT_PATH , ADMIN_KEY_PATH , ADMIN_CERT_PATH - the absolute paths to files that are used by kubectl.
+    - This can be passed by secret, the path can be the path where you going to mount your secret volumes.
+    - Note: Absolute paths only.
  - CRON_FREQUENCY - the 5-part frequency of the cron job. Default is a random
    time in the range `0-59 0-23 1-27 * *`

--- a/start.sh
+++ b/start.sh
@@ -40,6 +40,8 @@ if [ -n "${KUBECTL_ACCESS_SECURED+1}" ] && [ "${KUBECTL_ACCESS_SECURED,,}" = "tr
   kubectl config set-credentials default-admin --certificate-authority=${CA_CERT} --client-key=${ADMIN_KEY} --client-certificate=${ADMIN_CERT}
   kubectl config set-context default-system --cluster=default-cluster --user=default-admin
   kubectl config use-context default-system
+
+ echo "KUBECTL: OK!"
 fi
 
 # Start cron

--- a/start.sh
+++ b/start.sh
@@ -29,7 +29,7 @@ fi
 
 # The process that identify and setup the admin-key to KUBECTL
 # Note: This PATHS's has to be absolutes.
-if [ -n "${KUBECTL_ACCESS_SECURED+1}" ] && [ "${KUBECTL_ACCESS_SECURED,,}" = "true" ] && []; then
+if [ -n "${KUBECTL_ACCESS_SECURED+1}" ] && [ "${KUBECTL_ACCESS_SECURED,,}" = "true" ]; then
   echo "Configuring KUBECTL keys..."
   echo "MASTER_HOST : ${MASTER_HOST}"
   echo "CA_CERT_PATH : ${CA_CERT_PATH}"

--- a/start.sh
+++ b/start.sh
@@ -37,7 +37,7 @@ if [ -n "${KUBECTL_ACCESS_SECURED+1}" ] && [ "${KUBECTL_ACCESS_SECURED,,}" = "tr
   echo "ADMIN_CERT_PATH : ${ADMIN_CERT_PATH}"
 
   kubectl config set-cluster default-cluster --server=https://${MASTER_HOST} --certificate-authority=${CA_CERT_PATH}
-  Ckubectl config set-credentials default-admin --certificate-authority=${CA_CERT_PATH} --client-key=${ADMIN_KEY_PATH} --client-certificate=${ADMIN_CERT_PATH}
+  kubectl config set-credentials default-admin --certificate-authority=${CA_CERT_PATH} --client-key=${ADMIN_KEY_PATH} --client-certificate=${ADMIN_CERT_PATH}
   kubectl config set-context default-system --cluster=default-cluster --user=default-admin
   kubectl config use-context default-system
 

--- a/start.sh
+++ b/start.sh
@@ -27,6 +27,21 @@ if [ -n "${LETSENCRYPT_ENDPOINT+1}" ]; then
     echo "server = $LETSENCRYPT_ENDPOINT" >> /etc/letsencrypt/cli.ini
 fi
 
+# The process that identify and setup the admin-key to KUBECTL
+# Note: This PATHS's has to be absolutes.
+if [ -n "${KUBECTL_ACCESS_SECURED+1}" ] && [ "${KUBECTL_ACCESS_SECURED,,}" = "true" ] && []; then
+  echo "Configuring KUBECTL keys..."
+  echo "MASTER_HOST : ${MASTER_HOST}"
+    echo "CA_CERT_PATH : ${CA_CERT_PATH}"
+  echo "ADMIN_KEY_PATH : ${ADMIN_KEY_PATH}"
+  echo "ADMIN_CERT_PATH : ${ADMIN_CERT_PATH}"
+
+  kubectl config set-cluster default-cluster --server=https://${MASTER_HOST} --certificate-authority=${CA_CERT}
+  kubectl config set-credentials default-admin --certificate-authority=${CA_CERT} --client-key=${ADMIN_KEY} --client-certificate=${ADMIN_CERT}
+  kubectl config set-context default-system --cluster=default-cluster --user=default-admin
+  kubectl config use-context default-system
+fi
+
 # Start cron
 echo "Starting cron..."
 cron &

--- a/start.sh
+++ b/start.sh
@@ -32,7 +32,7 @@ fi
 if [ -n "${KUBECTL_ACCESS_SECURED+1}" ] && [ "${KUBECTL_ACCESS_SECURED,,}" = "true" ] && []; then
   echo "Configuring KUBECTL keys..."
   echo "MASTER_HOST : ${MASTER_HOST}"
-    echo "CA_CERT_PATH : ${CA_CERT_PATH}"
+  echo "CA_CERT_PATH : ${CA_CERT_PATH}"
   echo "ADMIN_KEY_PATH : ${ADMIN_KEY_PATH}"
   echo "ADMIN_CERT_PATH : ${ADMIN_CERT_PATH}"
 

--- a/start.sh
+++ b/start.sh
@@ -36,8 +36,8 @@ if [ -n "${KUBECTL_ACCESS_SECURED+1}" ] && [ "${KUBECTL_ACCESS_SECURED,,}" = "tr
   echo "ADMIN_KEY_PATH : ${ADMIN_KEY_PATH}"
   echo "ADMIN_CERT_PATH : ${ADMIN_CERT_PATH}"
 
-  kubectl config set-cluster default-cluster --server=https://${MASTER_HOST} --certificate-authority=${CA_CERT}
-  kubectl config set-credentials default-admin --certificate-authority=${CA_CERT} --client-key=${ADMIN_KEY} --client-certificate=${ADMIN_CERT}
+  kubectl config set-cluster default-cluster --server=https://${MASTER_HOST} --certificate-authority=${CA_CERT_PATH}
+  Ckubectl config set-credentials default-admin --certificate-authority=${CA_CERT_PATH} --client-key=${ADMIN_KEY_PATH} --client-certificate=${ADMIN_CERT_PATH}
   kubectl config set-context default-system --cluster=default-cluster --user=default-admin
   kubectl config use-context default-system
 


### PR DESCRIPTION
This branch has edited only "start.sh" file .
 What was done:
- Added the environment variables: CA_CERT_PATH , ADMIN_KEY_PATH , ADMIN_CERT_PATH, KUBECTL_ACCESS_SECURED. 
- Are used when the variable KUBECTL_ACCESS_SECURED is setted with "true" value (including the doble quote).

Description of each one:
- KUBECTL_ACCESS_SECURED: Used to active the kubectl configuration with the security key.
- CA_CERT_PATH: This variable is used to indicate the location where "ca.pem" is found.
- ADMIN_KEY_PATH: This variable is used to indicate the location where "admin-key.pem" is found.
- ADMIN_CERT_PATH: This variable is used to indicate the location where "admin.pem" is found.

NOTE: The file paths has to be ABSOLUTE PATH, ONLY.
