### PR TITLE
Added support for Kubernetes Ingress TLS support.

### DIFF
--- a/save_certs.sh
+++ b/save_certs.sh
@@ -40,6 +40,8 @@ cat << EOF | kubectl $ACTION -f -
  "data": {
    "proxycert": "$CERT",
    "proxykey": "$KEY",
+   "tls.crt": "$CERT",
+   "tls.key": "$KEY",   
    "dhparam": "$DHPARAM"
  }
 }


### PR DESCRIPTION
save_certs.sh will now also stores the keys calls tls.crt and tls.key in
the secret, allowing it to be used by the standard Kubernetes ingress
TLS support.

To use the secret simply add a tls section to your ingress spec, ie
assuming you saved the certs in a secret called ssl-for-mydomain:

...
spec:
  tls:
- hosts:
  - mydomain.com
    secretName: ssl-for-mydomain
    rules:
    ...
